### PR TITLE
Add verify_host_key config

### DIFF
--- a/scripts/homestead.rb
+++ b/scripts/homestead.rb
@@ -9,6 +9,9 @@ class Homestead
 
     # Allow SSH Agent Forward from The Box
     config.ssh.forward_agent = true
+      
+    # Configure Verfiy Host Key
+    config.ssh.verify_host_key = :never
 
     # Configure The Box
     config.vm.define settings['name'] ||= 'homestead-7'


### PR DESCRIPTION
The following deprecation error message may appear in some Vagrant installs:
```
verify_host_key: false is deprecated, use :never
```
Adding a config for verify_host_key addresses this issue.